### PR TITLE
use etcher instructions

### DIFF
--- a/intel-corei7-64.coffee
+++ b/intel-corei7-64.coffee
@@ -56,6 +56,13 @@ NUC_POWERON = 'Press the power on button on your Intel NUC.'
 
 NUC_BOOT_SETUP = 'Press F2 to enter Setup. Select the UEFI:SATA option under Boot Drive Order, save and exit Setup.'
 
+postProvisioningInstructions = [
+	instructions.BOARD_SHUTDOWN
+	instructions.REMOVE_INSTALL_MEDIA
+	NUC_POWERON
+	NUC_BOOT_SETUP
+]
+
 module.exports =
 	slug: 'intel-nuc'
 	aliases: [ 'nuc' ]
@@ -64,47 +71,14 @@ module.exports =
 	state: 'released'
 
 	stateInstructions:
-		postProvisioning: [
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			NUC_POWERON
-			NUC_BOOT_SETUP
-		]
+		postProvisioning: postProvisioningInstructions
 
-	instructions:
-		windows: [
-			instructions.WINDOWS_DISK_IMAGER_USB
-			instructions.EJECT_USB
-			instructions.FLASHER_WARNING
-			NUC_FLASH
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			NUC_POWERON
-			NUC_BOOT_SETUP
-		]
-		osx: [
-			instructions.OSX_PLUG_USB
-			instructions.OSX_UNMOUNT_USB
-			instructions.DD_BURN_IMAGE_USB
-			instructions.EJECT_USB
-			instructions.FLASHER_WARNING
-			NUC_FLASH
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			NUC_POWERON
-			NUC_BOOT_SETUP
-		]
-		linux: [
-			instructions.LINUX_DF_USB
-			instructions.DD_BURN_IMAGE_USB
-			instructions.EJECT_USB
-			instructions.FLASHER_WARNING
-			NUC_FLASH
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			NUC_POWERON
-			NUC_BOOT_SETUP
-		]
+	instructions: [
+		instructions.ETCHER_USB
+		instructions.EJECT_USB
+		instructions.FLASHER_WARNING
+		NUC_FLASH
+	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:
 		windows: 'http://docs.resin.io/#/pages/installing/gettingStarted-NUC.md#windows'


### PR DESCRIPTION
This makes the instructions use Etcher as primary image burning software.

To make it work: (from @emirotin) 
1. approve and merge resin-io/resin-device-types#7
2. update the resin-device-types submodule in this branch and update this PR
3. test how the JSON file is built (I've tested it myself by checking out the corresponding branch in a submodule)
4. approve and merge this PR
5. follow the standard procedure to release this device type and get it to img-maker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-os/resin-intel/4)
<!-- Reviewable:end -->
