### PR TITLE
recipes-kernel: enable module compression

### DIFF
--- a/layers/meta-resin-intel/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-resin-intel/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,1 +1,2 @@
-inherit kernel-resin
+MODULE_COMPRESS = "xz"
+inherit kernel-resin compress-kernel-modules


### PR DESCRIPTION
Connects to resin-os/meta-resin#264
Connects to resin-os/meta-resin#257

Reduce the image size. As far as size is concerned, "xz" produces
significantly better results than "gzip".

Signed-off-by: Michal Mazurek <michal@resin.io>