### PR TITLE
add edge alias

### DIFF
--- a/intel-corei7-64.coffee
+++ b/intel-corei7-64.coffee
@@ -65,7 +65,7 @@ postProvisioningInstructions = [
 
 module.exports =
 	slug: 'intel-nuc'
-	aliases: [ 'nuc' ]
+	aliases: [ 'nuc', 'edge' ]
 	name: 'Intel NUC'
 	arch: 'amd64'
 	state: 'released'


### PR DESCRIPTION
the addition of the `edge` alias enables to directly build dependent devices software on a proper x86 arch