### PR TITLE
Add meta-filesystem as we need aufs-utils on resin-intel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add meta-filesystem as we need aufs-utils [Andrei]
 * Add build support for resinos [Andrei]
 * Update resin-yocto-script to include changes in our image types [Theodor]
 * Replace the concept of a debug image with a development image [Theodor]

--- a/layers/meta-resin-intel/conf/samples/bblayers.conf.sample
+++ b/layers/meta-resin-intel/conf/samples/bblayers.conf.sample
@@ -9,6 +9,7 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/poky/meta \
     ${TOPDIR}/../layers/poky/meta-yocto \
     ${TOPDIR}/../layers/meta-openembedded/meta-oe \
+    ${TOPDIR}/../layers/meta-openembedded/meta-filesystems \
     ${TOPDIR}/../layers/meta-openembedded/meta-networking \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
     ${TOPDIR}/../layers/meta-intel \


### PR DESCRIPTION
Connects to resin-os/meta-resin#404-meta-fs-layer
@telphan @floion @petrosagg @petrosagg @michal-mazurek