### PR TITLE
Integrate old initramfs in the new framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Integrate our current initramfs in the new initramfs framework [Theodor]
+
 # v2.0.0-beta12.rev2 - 2017-02-28
 
 * Fix partition labels from last meta-resin update [Andrei]

--- a/layers/meta-resin-intel/recipes-bsp/grub/files/grub.cfg_internal
+++ b/layers/meta-resin-intel/recipes-bsp/grub/files/grub.cfg_internal
@@ -4,6 +4,5 @@ default=boot
 timeout=3
 
 menuentry 'boot'{
-linux /vmlinuz LABEL=resin-rootA root=/dev/ram0 rootwait
-initrd /initramfs
+linux /vmlinuz LABEL=resin-rootA rootwait
 }

--- a/layers/meta-resin-intel/recipes-core/images/resin-image-flasher.bbappend
+++ b/layers/meta-resin-intel/recipes-core/images/resin-image-flasher.bbappend
@@ -1,7 +1,10 @@
 include resin-image.inc
 
+IMAGE_DEPENDS_resinos-img_append_intel-corei7-64 = " core-image-minimal-initramfs:do_rootfs"
+
 # Put the initramfs inside the boot partition
 RESIN_BOOT_PARTITION_FILES_append_intel-corei7-64 = " \
+    core-image-minimal-initramfs-intel-corei7-64.cpio.gz:/initramfs \
     grub.cfg_external:/EFI/BOOT/grub.cfg \
     grub.cfg_internal: \
     "

--- a/layers/meta-resin-intel/recipes-core/images/resin-image-initramfs.bbappend
+++ b/layers/meta-resin-intel/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,1 +1,3 @@
 PACKAGE_INSTALL_append = " initramfs-module-labelrootfs"
+
+IMAGE_ROOTFS_MAXSIZE = "16384"

--- a/layers/meta-resin-intel/recipes-core/images/resin-image-initramfs.bbappend
+++ b/layers/meta-resin-intel/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,0 +1,1 @@
+PACKAGE_INSTALL_append = " initramfs-module-labelrootfs"

--- a/layers/meta-resin-intel/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-intel/recipes-core/images/resin-image.inc
@@ -4,9 +4,6 @@
 
 IMAGE_FSTYPES_append_intel-corei7-64 = " resinos-img"
 
-# Make sure we have the resin image and the initramfs ready
-IMAGE_DEPENDS_resinos-img_append_intel-corei7-64 = " core-image-minimal-initramfs:do_rootfs"
-
 # Do not support live USB stick
 NOISO_intel-corei7-64 = "1"
 NOHDD_intel-corei7-64 = "1"
@@ -14,7 +11,6 @@ NOHDD_intel-corei7-64 = "1"
 # Customize resinos-img
 RESIN_IMAGE_BOOTLOADER_intel-corei7-64 = "grub-efi"
 RESIN_BOOT_PARTITION_FILES_intel-corei7-64 = " \
-    core-image-minimal-initramfs-intel-corei7-64.cpio.gz:/initramfs \
     bootx64.efi:/EFI/BOOT/ \
     bzImage${KERNEL_INITRAMFS}-intel-corei7-64.bin:/vmlinuz \
     "

--- a/layers/meta-resin-intel/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-intel/recipes-core/images/resin-image.inc
@@ -16,5 +16,5 @@ RESIN_IMAGE_BOOTLOADER_intel-corei7-64 = "grub-efi"
 RESIN_BOOT_PARTITION_FILES_intel-corei7-64 = " \
     core-image-minimal-initramfs-intel-corei7-64.cpio.gz:/initramfs \
     bootx64.efi:/EFI/BOOT/ \
-    bzImage-intel-corei7-64.bin:/vmlinuz \
+    bzImage${KERNEL_INITRAMFS}-intel-corei7-64.bin:/vmlinuz \
     "

--- a/layers/meta-resin-intel/recipes-core/initrdscripts/files/labelrootfs
+++ b/layers/meta-resin-intel/recipes-core/initrdscripts/files/labelrootfs
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+labelrootfs_enabled() {
+    return 0
+}
+
+labelrootfs_run() {
+    echo "Waiting for udev to populate /dev/disk/by-label/$bootparam_LABEL... "
+    while :
+    do
+        if test -e /dev/disk/by-label/$bootparam_LABEL; then
+            break
+        fi
+        sleep 1
+    done
+    echo "Found $bootparam_LABEL label."
+
+    bootparam_root="/dev/disk/by-label/$bootparam_LABEL"
+}

--- a/layers/meta-resin-intel/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/layers/meta-resin-intel/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = " file://labelrootfs"
+
+do_install_append() {
+    install -m 0755 ${WORKDIR}/labelrootfs ${D}/init.d/88-labelrootfs
+}
+
+PACKAGES_append = " initramfs-module-labelrootfs"
+
+SUMMARY_initramfs-module-labelrootfs = "Discover rootfs based on label"
+RDEPENDS_initramfs-module-labelrootfs = "${PN}-base"
+FILES_initramfs-module-labelrootfs = "/init.d/88-labelrootfs"


### PR DESCRIPTION
Connects to resin-os/meta-resin#379

This PR is incomplete, because it awaits this (resin-os/meta-resin#594) to be merged.