### PR TITLE
Update poky to the latest morty revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update the Poky submodule [Will]
+
 # v2.0.0-rc4.rev1 - 2017-03-17
 
 * Update the meta-resin submodule to version v2.0.0-rc4 [Florin]


### PR DESCRIPTION
Connected to https://github.com/resin-os/resinos/issues/241
This should fix the issue with the file package failing to build.