### PR TITLE
Update Poky submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update the Poky submodule, which reverts previous change [Will]
 * Do not show kernel boot messages on the display for production images [Florin]
 * Update the Poky submodule [Will]
 


### PR DESCRIPTION

This updates the Poky submodule to the latest morty revision which reverts the previous change to the file package which reflects upstream's decision to put their repo back to how it was before.
