### PR TITLE
Enable more than four serial ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Add support for more than 4 serial ports [Will]
+
 # v2.0.0+rev2 - 2017-04-04
 
 * Bump resin-yocto-scripts to fix resinOS docker registry push [Andrei]

--- a/layers/meta-resin-intel/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-resin-intel/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -15,3 +15,13 @@ RESIN_CONFIGS_append_intel-corei7-64 = " dlm"
 RESIN_CONFIGS[dlm] = " \
     CONFIG_DLM=m \
     "
+
+#
+# Support for serial console and more than 4 serial ports
+#
+RESIN_CONFIGS_append_intel-corei7-64 = " serial_8250"
+RESIN_CONFIGS[serial_8250] = " \
+    CONFIG_SERIAL_8250_CONSOLE=y \
+    CONFIG_SERIAL_8250_NR_UARTS=32 \
+    CONFIG_SERIAL_8250_RUNTIME_UARTS=32 \
+    "


### PR DESCRIPTION
A user on gitter had an issue with an embedded x86 board that had some extra serial ports that weren't showing up. Increase the number of available serial ports to 32 (this is the value that Fedora uses for their kernel on i686 and x86_64). Also enable console on serial.