### PR TITLE
linux-yocto_%.bbappend: Enable kernel drivers needed for bluetooth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Activate kernel drivers for bluetooth to work on the Intel NUC when using the genericx86-64 machine [Florin]
+
 # v2.9.3+rev1
 ## (2018-01-09)
 

--- a/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -24,6 +24,16 @@ RESIN_CONFIGS[iwlwifi] = " \
     "
 
 #
+# Support Intel NUC Bluetooth
+#
+RESIN_CONFIGS_append = " nuc_bluetooth"
+RESIN_CONFIGS[nuc_bluetooth] = " \
+    CONFIG_BT_HCIUART=m \
+    CONFIG_BT_HCIUART_INTEL=y \
+    CONFIG_BT_HCIBTUSB=m \
+    "
+
+#
 # Support for DLM module
 #
 RESIN_CONFIGS_append = " dlm"


### PR DESCRIPTION
We need these kernel drivers for bluetooth to work on the Intel NUC when using
the genericx86-64 machine.

Signed-off-by: Florin Sarbu <florin@resin.io>