### PR TITLE
linux-yocto_%.bbappend: Enable VXLAN support as a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Enable VXLAN support [Florin]
 * Fix eMMC detection on some Atom based SoCs [Florin]
 
 # v2.9.7+rev2

--- a/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -86,3 +86,9 @@ RESIN_CONFIGS_append = " lpss"
 RESIN_CONFIGS[lpss] = " \
     CONFIG_X86_INTEL_LPSS=y \
 "
+
+# Enable vxlan support (requested by customer)
+RESIN_CONFIGS_append = " vxlan"
+RESIN_CONFIGS[vxlan] = " \
+    CONFIG_VXLAN=m \
+"


### PR DESCRIPTION
This is requested by customer

Signed-off-by: Florin Sarbu <florin@resin.io>