### PR TITLE
grub: Limit CPU cstate to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Limit the CPU cstate to 1 [Florin]
+
 # v2.12.5+rev1
 ## (2018-03-28)
 

--- a/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-dev
+++ b/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-dev
@@ -4,5 +4,5 @@ default=boot
 timeout=3
 
 menuentry 'boot'{
-linux /vmlinuz root=LABEL=resin-rootA rootwait
+linux /vmlinuz root=LABEL=resin-rootA rootwait intel_idle.max_cstate=1
 }

--- a/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-prod
+++ b/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-prod
@@ -4,5 +4,5 @@ default=boot
 timeout=0
 
 menuentry 'boot'{
-linux /vmlinuz root=LABEL=resin-rootA rootwait quiet loglevel=0 splash udev.log-priority=3 vt.global_cursor_default=0
+linux /vmlinuz root=LABEL=resin-rootA rootwait quiet loglevel=0 splash udev.log-priority=3 vt.global_cursor_default=0 intel_idle.max_cstate=1
 }


### PR DESCRIPTION
Some intel Atom SoCs tend to hang while transitioning to idle states.
See https://bugzilla.kernel.org/show_bug.cgi?id=109051 for one example of such bug report.

Thus we limit to 1 the cstate the CPU can go into.

Signed-off-by: Florin Sarbu <florin@resin.io>