### PR TITLE
linux-yocto: Include support for the RealSense camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Include support for the RealSense camera [Theodor]
+
 # v2.12.7+rev2
 ## (2018-05-21)
 

--- a/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_camera_formats_linux-yocto_4.4.patch
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_camera_formats_linux-yocto_4.4.patch
@@ -1,0 +1,174 @@
+From 4b7c35a5363d8d976143896951889dacc57d306b Mon Sep 17 00:00:00 2001
+From: Scott Ware <scott.r.ware@intel.com>
+Date: Mon, 27 Nov 2017 14:19:53 +0000
+Subject: [PATCH 1/4] Add support for RealSense camera formats
+
+Upstream-Status: Backport
+Signed-off-by: Scott Ware <scott.r.ware@intel.com>
+
+The patch was imported from the librealsense git server
+(git@github.com:IntelRealSense/librealsense.git) as of commit id
+bf914ddae7040fb9645bb61b6fcdb5084c337b70
+Signed-off-by: Theodor Gherzan <theodor@resin.io>
+---
+ drivers/media/usb/uvc/uvc_driver.c | 75 ++++++++++++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvcvideo.h   | 42 +++++++++++++++++++++
+ include/uapi/linux/videodev2.h     | 11 ++++++
+ 3 files changed, 128 insertions(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
+index 885f689..3e5300d 100644
+--- a/drivers/media/usb/uvc/uvc_driver.c
++++ b/drivers/media/usb/uvc/uvc_driver.c
+@@ -168,6 +168,76 @@ static struct uvc_format_desc uvc_fmts[] = {
+ 		.guid		= UVC_GUID_FORMAT_RW10,
+ 		.fcc		= V4L2_PIX_FMT_SRGGB10P,
+ 	},
++	{
++		.name		= "Raw data 10-bit (RW10)",
++		.guid		= UVC_GUID_FORMAT_RW10,
++		.fcc		= V4L2_PIX_FMT_RW10,
++	},
++	{
++		.name		= "Raw data 8-bit (RAW8)",
++		.guid		= UVC_GUID_FORMAT_RAW8,
++		.fcc		= V4L2_PIX_FMT_GREY,
++	},
++	{
++		.name		= "Raw data 16-bit (RW16)",
++		.guid		= UVC_GUID_FORMAT_RW16,
++		.fcc		= V4L2_PIX_FMT_RW16,
++	},
++	{
++		.name		= "Depth 16-bit (INVZ)",
++		.guid		= UVC_GUID_FORMAT_INVZ,
++		.fcc		= V4L2_PIX_FMT_Z16,
++	},
++	{
++		.name		= "Depth:IR 16:8 24-bit (INZI)",
++		.guid		= UVC_GUID_FORMAT_INZI,
++		.fcc		= V4L2_PIX_FMT_INZI,
++	},
++	{
++		.name		= "Depth 16-bit (INVR)",
++		.guid		= UVC_GUID_FORMAT_INVR,
++		.fcc		= V4L2_PIX_FMT_INVR,
++	},
++	{
++		.name		= "Depth:IR 16:8 24-bit (INRI)",
++		.guid		= UVC_GUID_FORMAT_INRI,
++		.fcc		= V4L2_PIX_FMT_INRI,
++	},
++	{
++		.name		= "Infrared 8-bit (INVI)",
++		.guid		= UVC_GUID_FORMAT_INVI,
++		.fcc		= V4L2_PIX_FMT_GREY,
++	},
++	{
++		.name		= "FlickerIR 8-bit (RELI)",
++		.guid		= UVC_GUID_FORMAT_RELI,
++		.fcc		= V4L2_PIX_FMT_RELI,
++	},
++	{
++		.name		= "Luminosity data 8-bit (L8)",
++		.guid		= UVC_GUID_FORMAT_L8,
++		.fcc		= V4L2_PIX_FMT_GREY,
++	},
++	{
++		.name		= "Luminosity data 16-bit (L16)",
++		.guid		= UVC_GUID_FORMAT_L16,
++		.fcc		= V4L2_PIX_FMT_Y16,
++	},
++	{
++		.name		= "Depth data 16-bit (D16)",
++		.guid		= UVC_GUID_FORMAT_D16,
++		.fcc		= V4L2_PIX_FMT_Z16,
++	},
++	{
++		.name		= "16-bit Bayer BGBG/GRGR",
++		.guid		= UVC_GUID_FORMAT_BAYER16,
++		.fcc		= V4L2_PIX_FMT_SBGGR16,
++	},
++	{
++		.name		= "Packed raw data 10-bit",
++		.guid		= UVC_GUID_FORMAT_W10,
++		.fcc		= V4L2_PIX_FMT_W10,
++	},
+ };
+ 
+ /* ------------------------------------------------------------------------
+diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
+index 7e4d3ee..629afdf 100644
+--- a/drivers/media/usb/uvc/uvcvideo.h
++++ b/drivers/media/usb/uvc/uvcvideo.h
+@@ -131,6 +131,45 @@
+ #define UVC_GUID_FORMAT_RW10 \
+ 	{ 'R',  'W',  '1',  '0', 0x00, 0x00, 0x10, 0x00, \
+ 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_RAW8 \
++	{ 'R',  'A',  'W',  '8', 0x66, 0x1a, 0x42, 0xa2, \
++     	 0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
++#define UVC_GUID_FORMAT_RW16 \
++	{ 'R',  'W',  '1',  '6', 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_INVZ \
++	{ 'I',  'N',  'V',  'Z', 0x90, 0x2d, 0x58, 0x4a, \
++	 0x92, 0x0b, 0x77, 0x3f, 0x1f, 0x2c, 0x55, 0x6b}
++#define UVC_GUID_FORMAT_INZI \
++	{ 'I',  'N',  'Z',  'I', 0x66, 0x1a, 0x42, 0xa2, \
++	 0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
++#define UVC_GUID_FORMAT_INVR \
++	{ 'I',  'N',  'V',  'R', 0x90, 0x2d, 0x58, 0x4a, \
++	 0x92, 0x0b, 0x77, 0x3f, 0x1f, 0x2c, 0x55, 0x6b}
++#define UVC_GUID_FORMAT_INRI \
++	{ 'I',  'N',  'R',  'I', 0x90, 0x2d, 0x58, 0x4a, \
++	 0x92, 0x0b, 0x77, 0x3f, 0x1f, 0x2c, 0x55, 0x6b}
++#define UVC_GUID_FORMAT_INVI \
++	{ 'I',  'N',  'V',  'I', 0xdb, 0x57, 0x49, 0x5e, \
++	 0x8e, 0x3f, 0xf4, 0x79, 0x53, 0x2b, 0x94, 0x6f}
++#define UVC_GUID_FORMAT_RELI \
++	{ 'R',  'E',  'L',  'I', 0x14, 0x13, 0x43, 0xf9, \
++	 0xa7, 0x5a, 0xee, 0x6b, 0xbf, 0x01, 0x2e, 0x23}
++#define UVC_GUID_FORMAT_L8 \
++	{ '2', 0x00,  0x00,  0x00, 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_L16 \
++	{ 'Q', 0x00,  0x00,  0x00, 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_D16 \
++	{ 'P', 0x00,  0x00,  0x00, 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_BAYER16 \
++	{ 'R',  'W',  '1',  '6', 0x66, 0x1a, 0x42, 0xa2, \
++        0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
++#define UVC_GUID_FORMAT_W10 \
++	{ 'W',  '1',  '0',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
+ 
+ /* ------------------------------------------------------------------------
+  * Driver specific constants.
+diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
+index 421d274..ec1a577 100644
+--- a/include/uapi/linux/videodev2.h
++++ b/include/uapi/linux/videodev2.h
+@@ -624,6 +624,17 @@ struct v4l2_pix_format {
+ #define V4L2_PIX_FMT_Y8I      v4l2_fourcc('Y', '8', 'I', ' ') /* Greyscale 8-bit L/R interleaved */
+ #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
+ #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
++#define V4L2_PIX_FMT_Y8       v4l2_fourcc('Y', '8', ' ', ' ') /* Greyscale 8-bit */
++#define V4L2_PIX_FMT_RAW8     v4l2_fourcc('R', 'A', 'W', '8') /* Raw data 8-bit */
++#define V4L2_PIX_FMT_RW10     v4l2_fourcc('R', 'W', '1', '0') /* Raw data 10-bit */
++#define V4L2_PIX_FMT_RW16     v4l2_fourcc('R', 'W', '1', '6') /* Raw data 16-bit */
++#define V4L2_PIX_FMT_INVZ     v4l2_fourcc('I', 'N', 'V', 'Z') /* 16 Depth */
++#define V4L2_PIX_FMT_INZI     v4l2_fourcc('I', 'N', 'Z', 'I') /* 24 Depth/IR 16:8 */
++#define V4L2_PIX_FMT_INVR     v4l2_fourcc('I', 'N', 'V', 'R') /* 16 Depth */
++#define V4L2_PIX_FMT_INRI     v4l2_fourcc('I', 'N', 'R', 'I') /* 24 Depth/IR 16:8 */
++#define V4L2_PIX_FMT_INVI     v4l2_fourcc('I', 'N', 'V', 'I') /* 8 IR */
++#define V4L2_PIX_FMT_RELI     v4l2_fourcc('R', 'E', 'L', 'I') /* 8 IR alternating on off illumination */
++#define V4L2_PIX_FMT_W10      v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
+ 
+ /* SDR formats - used only for Software Defined Radio devices */
+ #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */
+-- 
+1.9.1
+

--- a/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_hid_linux-yocto_4.4.patch
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_hid_linux-yocto_4.4.patch
@@ -1,0 +1,186 @@
+From c8f0b4d94aca82dc7f8eae856db98a34941c3ce5 Mon Sep 17 00:00:00 2001
+From: Scott Ware <scott.r.ware@intel.com>
+Date: Mon, 27 Nov 2017 14:34:23 +0000
+Subject: [PATCH 2/4] Realsense HID
+
+Upstream-Status: Backpot
+Signed-off-by: Scott Ware <scott.r.ware@intel.com>
+
+The patch was imported from the librealsense git server
+(git@github.com:IntelRealSense/librealsense.git) as of commit id
+bf914ddae7040fb9645bb61b6fcdb5084c337b70
+Signed-off-by: Theodor Gherzan <theodor@resin.io>
+---
+ drivers/iio/accel/hid-sensor-accel-3d.c | 30 ++++++++++++++++++++++--------
+ drivers/iio/gyro/hid-sensor-gyro-3d.c   | 32 +++++++++++++++++++++++---------
+ include/linux/hid-sensor-ids.h          |  1 +
+ 3 files changed, 46 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/iio/accel/hid-sensor-accel-3d.c b/drivers/iio/accel/hid-sensor-accel-3d.c
+index ab1e238..5de9718 100644
+--- a/drivers/iio/accel/hid-sensor-accel-3d.c
++++ b/drivers/iio/accel/hid-sensor-accel-3d.c
+@@ -42,11 +42,13 @@ struct accel_3d_state {
+ 	struct hid_sensor_hub_callbacks callbacks;
+ 	struct hid_sensor_common common_attributes;
+ 	struct hid_sensor_hub_attribute_info accel[ACCEL_3D_CHANNEL_MAX];
+-	u32 accel_val[ACCEL_3D_CHANNEL_MAX];
++	/* Reserve for 3 channels + padding + timestamp */
++	u32 accel_val[ACCEL_3D_CHANNEL_MAX + 3];
+ 	int scale_pre_decml;
+ 	int scale_post_decml;
+ 	int scale_precision;
+ 	int value_offset;
++	int64_t timestamp;
+ };
+ 
+ static const u32 accel_3d_addresses[ACCEL_3D_CHANNEL_MAX] = {
+@@ -87,7 +89,8 @@ static const struct iio_chan_spec accel_3d_channels[] = {
+ 		BIT(IIO_CHAN_INFO_SAMP_FREQ) |
+ 		BIT(IIO_CHAN_INFO_HYSTERESIS),
+ 		.scan_index = CHANNEL_SCAN_INDEX_Z,
+-	}
++	},
++	IIO_CHAN_SOFT_TIMESTAMP(3)
+ };
+ 
+ /* Adjust channel real bits based on report descriptor */
+@@ -192,11 +195,11 @@ static const struct iio_info accel_3d_info = {
+ };
+ 
+ /* Function to push data to buffer */
+-static void hid_sensor_push_data(struct iio_dev *indio_dev, const void *data,
+-	int len)
++static void hid_sensor_push_data(struct iio_dev *indio_dev, void *data,
++				 int len, int64_t timestamp)
+ {
+ 	dev_dbg(&indio_dev->dev, "hid_sensor_push_data\n");
+-	iio_push_to_buffers(indio_dev, data);
++	iio_push_to_buffers_with_timestamp(indio_dev, data, timestamp);
+ }
+ 
+ /* Callback handler to send event after all samples are received and captured */
+@@ -208,10 +211,17 @@ static int accel_3d_proc_event(struct hid_sensor_hub_device *hsdev,
+ 	struct accel_3d_state *accel_state = iio_priv(indio_dev);
+ 
+ 	dev_dbg(&indio_dev->dev, "accel_3d_proc_event\n");
+-	if (atomic_read(&accel_state->common_attributes.data_ready))
++	if (atomic_read(&accel_state->common_attributes.data_ready)) {
++		if (!accel_state->timestamp)
++			accel_state->timestamp = iio_get_time_ns();
++
+ 		hid_sensor_push_data(indio_dev,
+-				accel_state->accel_val,
+-				sizeof(accel_state->accel_val));
++				     accel_state->accel_val,
++				     sizeof(accel_state->accel_val),
++				     accel_state->timestamp);
++
++		accel_state->timestamp = 0;
++	}
+ 
+ 	return 0;
+ }
+@@ -236,6 +246,10 @@ static int accel_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+ 						*(u32 *)raw_data;
+ 		ret = 0;
+ 	break;
++	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
++		accel_state->timestamp = *(int64_t *)raw_data;
++		ret = 0;
++	break;
+ 	default:
+ 		break;
+ 	}
+diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
+index c67ce2a..3da24f0 100644
+--- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
++++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
+@@ -42,11 +42,13 @@ struct gyro_3d_state {
+ 	struct hid_sensor_hub_callbacks callbacks;
+ 	struct hid_sensor_common common_attributes;
+ 	struct hid_sensor_hub_attribute_info gyro[GYRO_3D_CHANNEL_MAX];
+-	u32 gyro_val[GYRO_3D_CHANNEL_MAX];
++	/* Reserve for 3 channels + padding + timestamp */
++	u32 gyro_val[GYRO_3D_CHANNEL_MAX + 3];
+ 	int scale_pre_decml;
+ 	int scale_post_decml;
+ 	int scale_precision;
+ 	int value_offset;
++	int64_t timestamp;
+ };
+ 
+ static const u32 gyro_3d_addresses[GYRO_3D_CHANNEL_MAX] = {
+@@ -87,7 +89,8 @@ static const struct iio_chan_spec gyro_3d_channels[] = {
+ 		BIT(IIO_CHAN_INFO_SAMP_FREQ) |
+ 		BIT(IIO_CHAN_INFO_HYSTERESIS),
+ 		.scan_index = CHANNEL_SCAN_INDEX_Z,
+-	}
++	},
++	IIO_CHAN_SOFT_TIMESTAMP(3)
+ };
+ 
+ /* Adjust channel real bits based on report descriptor */
+@@ -192,11 +195,11 @@ static const struct iio_info gyro_3d_info = {
+ };
+ 
+ /* Function to push data to buffer */
+-static void hid_sensor_push_data(struct iio_dev *indio_dev, const void *data,
+-	int len)
++static void hid_sensor_push_data(struct iio_dev *indio_dev, void *data,
++				 int len, int64_t timestamp)
+ {
+ 	dev_dbg(&indio_dev->dev, "hid_sensor_push_data\n");
+-	iio_push_to_buffers(indio_dev, data);
++	iio_push_to_buffers_with_timestamp(indio_dev, data, timestamp);
+ }
+ 
+ /* Callback handler to send event after all samples are received and captured */
+@@ -208,10 +211,17 @@ static int gyro_3d_proc_event(struct hid_sensor_hub_device *hsdev,
+ 	struct gyro_3d_state *gyro_state = iio_priv(indio_dev);
+ 
+ 	dev_dbg(&indio_dev->dev, "gyro_3d_proc_event\n");
+-	if (atomic_read(&gyro_state->common_attributes.data_ready))
+-		hid_sensor_push_data(indio_dev,
+-				gyro_state->gyro_val,
+-				sizeof(gyro_state->gyro_val));
++	if (atomic_read(&gyro_state->common_attributes.data_ready)) {
++		if (!gyro_state->timestamp)
++			gyro_state->timestamp = iio_get_time_ns();
++
++ 		hid_sensor_push_data(indio_dev,
++				     gyro_state->gyro_val,
++				     sizeof(gyro_state->gyro_val),
++				     gyro_state->timestamp);
++
++		gyro_state->timestamp = 0;
++	}
+ 
+ 	return 0;
+ }
+@@ -236,6 +246,10 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+ 						*(u32 *)raw_data;
+ 		ret = 0;
+ 	break;
++	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
++		gyro_state->timestamp = *(int64_t *)raw_data;
++		ret = 0;
++	break;
+ 	default:
+ 		break;
+ 	}
+diff --git a/include/linux/hid-sensor-ids.h b/include/linux/hid-sensor-ids.h
+index f2ee90a..063aa1f 100644
+--- a/include/linux/hid-sensor-ids.h
++++ b/include/linux/hid-sensor-ids.h
+@@ -95,6 +95,7 @@
+ #define HID_USAGE_SENSOR_TIME_HOUR				0x200525
+ #define HID_USAGE_SENSOR_TIME_MINUTE				0x200526
+ #define HID_USAGE_SENSOR_TIME_SECOND				0x200527
++#define HID_USAGE_SENSOR_TIME_TIMESTAMP			0x200529
+ 
+ /* Units */
+ #define HID_USAGE_SENSOR_UNITS_NOT_SPECIFIED			0x00
+-- 
+1.9.1
+

--- a/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_metadata_linux-yocto_4.4.patch
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_metadata_linux-yocto_4.4.patch
@@ -1,0 +1,215 @@
+From c5811c81372e9fe5b5216074a194c1be1ff12d1f Mon Sep 17 00:00:00 2001
+From: Scott Ware <scott.r.ware@intel.com>
+Date: Mon, 27 Nov 2017 15:26:49 +0000
+Subject: [PATCH 3/4] Realsense metadata
+
+Upstream-status: Backport
+Signed-off-by: Scott Ware <scott.r.ware@intel.com>
+
+The patch was imported from the librealsense git server
+(git@github.com:IntelRealSense/librealsense.git) as of commit id
+bf914ddae7040fb9645bb61b6fcdb5084c337b70
+Signed-off-by: Theodor Gherzan <theodor@resin.io>
+---
+ drivers/media/usb/uvc/uvc_driver.c | 126 +++++++++++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_video.c  |  18 ++++--
+ drivers/media/usb/uvc/uvcvideo.h   |   3 +-
+ 3 files changed, 140 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
+index 3e5300d..6de2173 100644
+--- a/drivers/media/usb/uvc/uvc_driver.c
++++ b/drivers/media/usb/uvc/uvc_driver.c
+@@ -2730,6 +2730,132 @@ static struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_QUIRK_FORCE_Y8 },
++	/* Intel D400/PSR depth camera*/
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0ad1,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D410/ASR depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0ad2,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D415/ASRC depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0ad3,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D430/AWG depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0ad4,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D450/AWGT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0ad5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D420/PWG depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0af6,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D420_MM/PWGT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0afe,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D410_MM/ASRT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0aff,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D400_MM/PSRT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b00,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D430_MM/AWGCT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b01,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D460/DS5U depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b03,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D435/AWGC depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b07,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel SR300 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0aa5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D405 S depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b0c,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
+ 	/* Generic USB Video Class */
+ 	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, 0) },
+ 	{}
+diff --git a/drivers/media/usb/uvc/uvc_video.c b/drivers/media/usb/uvc/uvc_video.c
+index 2b276ab..7b61941 100644
+--- a/drivers/media/usb/uvc/uvc_video.c
++++ b/drivers/media/usb/uvc/uvc_video.c
+@@ -1232,9 +1232,12 @@ static void uvc_video_decode_bulk(struct urb *urb, struct uvc_streaming *stream,
+ 	if (stream->bulk.header_size == 0 && !stream->bulk.skip_payload) {
+ 		do {
+ 			ret = uvc_video_decode_start(stream, buf, mem, len);
+-			if (ret == -EAGAIN)
+-				buf = uvc_queue_next_buffer(&stream->queue,
+-							    buf);
++			if (ret == -EAGAIN) {
++				if (stream->dev->quirks & UVC_QUIRK_APPEND_UVC_HEADER)
++					uvc_video_decode_data(stream, buf, stream->bulk.header,256);
++
++				buf = uvc_queue_next_buffer(&stream->queue,buf);
++			}
+ 		} while (ret == -EAGAIN);
+ 
+ 		/* If an error occurred skip the rest of the payload. */
+@@ -1266,9 +1269,12 @@ static void uvc_video_decode_bulk(struct urb *urb, struct uvc_streaming *stream,
+ 		if (!stream->bulk.skip_payload && buf != NULL) {
+ 			uvc_video_decode_end(stream, buf, stream->bulk.header,
+ 				stream->bulk.payload_size);
+-			if (buf->state == UVC_BUF_STATE_READY)
+-				buf = uvc_queue_next_buffer(&stream->queue,
+-							    buf);
++			if (buf->state == UVC_BUF_STATE_READY) {
++				if (stream->dev->quirks & UVC_QUIRK_APPEND_UVC_HEADER)
++					uvc_video_decode_data(stream, buf, stream->bulk.header, stream->bulk.header_size);
++
++				buf = uvc_queue_next_buffer(&stream->queue, buf);
++			}
+ 		}
+ 
+ 		stream->bulk.header_size = 0;
+diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
+index 629afdf..e4fe3a3 100644
+--- a/drivers/media/usb/uvc/uvcvideo.h
++++ b/drivers/media/usb/uvc/uvcvideo.h
+@@ -179,7 +179,7 @@
+ /* Maximum number of packets per URB. */
+ #define UVC_MAX_PACKETS		32
+ /* Maximum status buffer size in bytes of interrupt URB. */
+-#define UVC_MAX_STATUS_SIZE	16
++#define UVC_MAX_STATUS_SIZE	32
+ 
+ #define UVC_CTRL_CONTROL_TIMEOUT	300
+ #define UVC_CTRL_STREAMING_TIMEOUT	5000
+@@ -200,6 +200,7 @@
+ #define UVC_QUIRK_RESTRICT_FRAME_RATE	0x00000200
+ #define UVC_QUIRK_RESTORE_CTRLS_ON_INIT	0x00000400
+ #define UVC_QUIRK_FORCE_Y8		0x00000800
++#define UVC_QUIRK_APPEND_UVC_HEADER	0x00001000
+ 
+ /* Format flags */
+ #define UVC_FMT_FLAG_COMPRESSED		0x00000001
+-- 
+1.9.1
+

--- a/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_powerlinefrequency_control_fix_linux-yocto_4.4.patch
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/files/realsense_powerlinefrequency_control_fix_linux-yocto_4.4.patch
@@ -1,0 +1,31 @@
+From e53ff5bf09a54af77f3f2f7c7282e38c33093377 Mon Sep 17 00:00:00 2001
+From: Scott Ware <scott.r.ware@intel.com>
+Date: Mon, 27 Nov 2017 15:27:40 +0000
+Subject: [PATCH 4/4] Fix incomplete PowerLineFrequency enumeration map
+
+Upstream-Status: Backport
+Signed-off-by: Scott Ware <scott.r.ware@intel.com>
+
+The patch was imported from the librealsense git server
+(git@github.com:IntelRealSense/librealsense.git) as of commit id
+bf914ddae7040fb9645bb61b6fcdb5084c337b70
+Signed-off-by: Theodor Gherzan <theodor@resin.io>
+---
+ drivers/media/usb/uvc/uvc_ctrl.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_ctrl.c b/drivers/media/usb/uvc/uvc_ctrl.c
+index 3e59b28..888d32c 100644
+--- a/drivers/media/usb/uvc/uvc_ctrl.c
++++ b/drivers/media/usb/uvc/uvc_ctrl.c
+@@ -356,6 +356,7 @@ static struct uvc_menu_info power_line_frequency_controls[] = {
+ 	{ 0, "Disabled" },
+ 	{ 1, "50 Hz" },
+ 	{ 2, "60 Hz" },
++	{ 3, "Auto" },
+ };
+ 
+ static struct uvc_menu_info exposure_auto_controls[] = {
+-- 
+1.9.1
+

--- a/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_4.4.bbappend
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_4.4.bbappend
@@ -1,0 +1,30 @@
+inherit kernel-resin
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+  file://realsense_hid_linux-yocto_4.4.patch \
+  file://realsense_metadata_linux-yocto_4.4.patch \
+  file://realsense_powerlinefrequency_control_fix_linux-yocto_4.4.patch \
+  file://realsense_camera_formats_linux-yocto_4.4.patch \
+  "
+
+RESIN_CONFIGS_append = " uvc"                                                                                                                                                  
+                                                                                                                                                                                  
+RESIN_CONFIGS[uvc] = " \                                                                                                                                                       
+		CONFIG_USB_VIDEO_CLASS=m \
+		CONFIG_USB_VIDEO_CLASS_INPUT_EDEV=y \
+		" 
+
+RESIN_CONFIGS_DEPS[uvc] = " \
+    CONFIG_MEDIA_CAMERA_SUPPORT=y \
+		CONFIG_VIDEO_V4L2_SUBDEV_API=y \
+		CONFIG_VIDEO_V4L2=m \
+		CONFIG_VIDEOBUF2_CORE=m \
+		CONFIG_VIDEOBUF2_MEMOPS=m \
+		CONFIG_VIDEOBUF2_VMALLOC=m \
+		CONFIG_MEDIA_USB_SUPPORT=y \
+		CONFIG_USB_GSPCA=m \
+		CONFIG_SND_USB=y \
+		CONFIG_SND_USB_AUDIO=m \
+    "


### PR DESCRIPTION
Closes #127 

General tests:
- [x] Tested image on device

Specific tets:
- [x] RealSense camera is picked shows up as /dev/video[1/0]
- [x] Linux kernel uses the correct driver for the RealSense camera