### PR TITLE
local.conf.sample: Delete references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Delete references to obsolete RESIN_CONNECTABLE* variables [Florin]
+
 # v2.14.0+rev1
 ## (2018-07-18)
 

--- a/layers/meta-resin-genericx86/conf/samples/local.conf.sample
+++ b/layers/meta-resin-genericx86/conf/samples/local.conf.sample
@@ -2,8 +2,6 @@
 #MACHINE ?= "genericx86-64"
 
 # More info meta-resin/README.md
-#RESIN_CONNECTABLE ?= "1"
-#RESIN_CONNECTABLE_ENABLE_SERVICES ?= "0"
 #TARGET_REPOSITORY ?= ""
 #TARGET_TAG ?= ""
 


### PR DESCRIPTION
to RESIN_CONNECTABLE* variables

meta-resin 2.14.0 will allow building of one image which by default is unmanaged.
The conversion between managed and unmanaged will be done through the os-config tool
at boot time, based on the existence of resinio configuration parameters in config.json,
so we remove the references to these obsolete variables from here.

Signed-off-by: Florin Sarbu <florin@resin.io>