### PR TITLE
grub-efi_%.bbappend: Remove runtime dependency on grub-common

### DIFF
--- a/layers/meta-resin-genericx86/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/layers/meta-resin-genericx86/recipes-bsp/grub/grub-efi_%.bbappend
@@ -14,3 +14,5 @@ do_deploy_append() {
         install -m 644 ${WORKDIR}/grub.cfg_internal-prod ${DEPLOYDIR}/grub.cfg_internal
     fi
 }
+
+RDEPENDS_${PN}_class-target_remove = "grub-common"


### PR DESCRIPTION
We do not need the grub utilities in the rootfs.

Changelog-entry: Do not install grub-common in the rootfs
Signed-off-by: Florin Sarbu <florin@resin.io>