### PR TITLE
Add support to load kernel from rootfs

### DIFF
--- a/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_external
+++ b/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_external
@@ -4,5 +4,6 @@ default=boot
 timeout=3
 
 menuentry 'flash'{
-linux /vmlinuz root=LABEL=flash-rootA rootwait
+search --set=root --label flash-rootA
+linux /boot/bzImage root=LABEL=flash-rootA rootwait
 }

--- a/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-dev
+++ b/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-dev
@@ -4,5 +4,6 @@ default=boot
 timeout=3
 
 menuentry 'boot'{
-linux /vmlinuz root=LABEL=resin-rootA rootwait intel_idle.max_cstate=1
+search --set=root --label resin-rootA
+linux /boot/bzImage root=LABEL=resin-rootA rootwait intel_idle.max_cstate=1
 }

--- a/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-prod
+++ b/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal-prod
@@ -4,5 +4,6 @@ default=boot
 timeout=0
 
 menuentry 'boot'{
-linux /vmlinuz root=LABEL=resin-rootA rootwait quiet loglevel=0 splash udev.log-priority=3 vt.global_cursor_default=0 intel_idle.max_cstate=1
+search --set=root --label resin-rootA
+linux /boot/bzImage root=LABEL=resin-rootA rootwait quiet loglevel=0 splash udev.log-priority=3 vt.global_cursor_default=0 intel_idle.max_cstate=1
 }

--- a/layers/meta-resin-genericx86/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-genericx86/recipes-core/images/resin-image.inc
@@ -12,7 +12,6 @@ NOHDD = "1"
 RESIN_IMAGE_BOOTLOADER = "grub-efi grub"
 RESIN_BOOT_PARTITION_FILES = " \
     grub-efi-bootx64.efi:/EFI/BOOT/bootx64.efi \
-    bzImage${KERNEL_INITRAMFS}-genericx86-64.bin:/vmlinuz \
     grub:/grub/ \
     grub/i386-pc:/grub/i386-pc/ \
     "


### PR DESCRIPTION
When resin-os/meta-resin#1153 is merged in meta-resin, the kernel will only be available in the rootfs partition. And prevented to be installed into the boot partition.

Add support to load the kernel from the rootfs partition.