### PR TITLE
os-config: Re-add UPX compression

### DIFF
--- a/layers/meta-resin-genericx86/recipes-core/os-config/os-config_%.bbappend
+++ b/layers/meta-resin-genericx86/recipes-core/os-config/os-config_%.bbappend
@@ -1,1 +1,0 @@
-FILES_COMPRESS = ""


### PR DESCRIPTION
Now meta-resin upgraded UPX to version 3.95 which fixes the segfaults
we have been seeing when compressing os-config on x86 platforms.

Changelog-entry: Re-add UPX compression for os-config
Signed-off-by: Florin Sarbu <florin@resin.io>