### PR TITLE
linux-yocto: Activate CONFIG_SND_DYNAMIC_MINORS in kernel

### DIFF
--- a/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-resin-genericx86/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -174,3 +174,9 @@ RESIN_CONFIGS[gpio_i2c_kempld] = " \
     CONFIG_GPIO_KEMPLD=m \
     CONFIG_I2C_KEMPLD=m \
 "
+
+# requested by customer
+RESIN_CONFIGS_append = " snd_dyn_minors"
+RESIN_CONFIGS[snd_dyn_minors] = " \
+    CONFIG_SND_DYNAMIC_MINORS=y \
+"


### PR DESCRIPTION
Changelog-entry: linux-yocto: Activate CONFIG_SND_DYNAMIC_MINORS in kernel
Signed-off-by: Sebastian Panceac <sebastian@resin.io>