### PR TITLE
usb-modeswitch_2.5.0.bbappend: Work around usb_modeswitch crash

### DIFF
--- a/layers/meta-resin-genericx86/recipes-support/usb-modeswitch/files/usb_modeswitch_avoid_coredump.patch
+++ b/layers/meta-resin-genericx86/recipes-support/usb-modeswitch/files/usb_modeswitch_avoid_coredump.patch
@@ -1,0 +1,24 @@
+This works around a core dump when running the usb_modeswitch systemd service
+on 64 bits platforms (generic Intel x86-64 platforms, NVidia Jetson TX2 etc.):
+
+usb_modeswitch_dispatcher[1376]: usb_modeswitch_dispatcher: malloc.c:2415: sysmalloc:
+Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE &&prev_inuse (old_top) &&
+((unsigned long) old_end & (pagesize - 1)) == 0)' failed. Oct 25 07:59:22 6f166e9 systemd[1]: usb_modeswitch@1-2:1.0.service:
+Main process exited, code=dumped, status=6/ABRT Oct 25 07:59:22 6f166e9 systemd[1]: usb_modeswitch@1-2:1.0.service:
+Unit entered failed state. Oct 25 07:59:22 6f166e9 systemd[1]: usb_modeswitch@1-2:1.0.service: Failed with result 'core-dump'.
+
+Signed-off-by: Florin Sarbu <florin@balena.io>
+Upstream-status: Pending
+
+Index: usb-modeswitch-2.5.0/usb_modeswitch@.service
+===================================================================
+--- usb-modeswitch-2.5.0.orig/usb_modeswitch@.service
++++ usb-modeswitch-2.5.0/usb_modeswitch@.service
+@@ -2,6 +2,7 @@
+ Description=USB_ModeSwitch_%i
+ 
+ [Service]
++StandardOutput=journal+console
+ Type=oneshot
+ ExecStart=/usr/sbin/usb_modeswitch_dispatcher --switch-mode %i
+ #ExecStart=/bin/echo %i

--- a/layers/meta-resin-genericx86/recipes-support/usb-modeswitch/usb-modeswitch_2.5.0.bbappend
+++ b/layers/meta-resin-genericx86/recipes-support/usb-modeswitch/usb-modeswitch_2.5.0.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+SRC_URI += "file://usb_modeswitch_avoid_coredump.patch"


### PR DESCRIPTION
On 64 bits platforms (generic Intel x86-64, NVidia Jetson TX2),
the systemd usb-modeswitch service will core dump when starting.

Changelog-entry: Workaround for usb_modeswitch crash on 64 bits platforms
Signed-off-by: Florin Sarbu <florin@balena.io>