### PR TITLE
grub: Temporarily disable rollbacks

### DIFF
--- a/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal_template
+++ b/layers/meta-resin-genericx86/recipes-bsp/grub/files/grub.cfg_internal_template
@@ -8,7 +8,7 @@ timeout=@@TIMEOUT@@
 resin_root_part=2
 upgrade_available=0
 
-load_env
+bootcount=0
 
 if [ ${upgrade_available} = 1 ] ; then
  if [ ${bootcount} = 1 ] ; then


### PR DESCRIPTION
At this point we need to figure out more scenarios that would trigger
a reboot before healthcheck actually runs (such as supervisor triggered
reboots).
Such an early reboot is not an indication of a hostOS update failure and
so we do not wish for rollbacks to take place in these scenarios.

Until all corner cases are discussed and handled in the OS, we disable
rollback functionality.

Changelog-entry: Temporarily disable rollback functionality
Signed-off-by: Florin Sarbu <florin@balena.io>